### PR TITLE
fix: accurate context usage badge counting

### DIFF
--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "db-mcp"
-version = "0.5.7"
+version = "0.5.8"
 description = "MCP server for database semantics and query intelligence"
 requires-python = ">=3.13"
 dependencies = [


### PR DESCRIPTION
## Bug
All context folders showed identical usage counts (e.g., 16x) and files showed no usage badges.

## Root Cause
The shell command heuristic (Source 1) extracted **search terms** (not file paths) and then created phantom entries across **all 6 context directories** for each term. So a single `grep "venue" examples/` would create entries for `schema/venue`, `examples/venue`, `domain/venue`, etc.

## Fix
- Replace the broken heuristic with a regex that extracts actual file paths from commands (e.g., `cat schema/descriptions.yaml` → `schema/descriptions.yaml`)
- Fix Source 3 (resource reads) to break after first directory match
- Add `metrics` to tracked context directories
- Bump to v0.5.8