### PR TITLE
fix: respect supports_validate_sql=false in run_sql instructions

### DIFF
--- a/packages/core/tests/test_server_instructions.py
+++ b/packages/core/tests/test_server_instructions.py
@@ -1,0 +1,20 @@
+"""Tests that server instructions adapt based on connector capabilities."""
+
+from db_mcp.server import (
+    INSTRUCTIONS_SHELL_MODE,
+    _strip_validate_sql_from_instructions,
+)
+
+
+def test_instructions_omit_validate_when_unsupported():
+    """When supports_validate_sql=false, instructions drop validate_sql."""
+    result = _strip_validate_sql_from_instructions(INSTRUCTIONS_SHELL_MODE)
+
+    assert "validate_sql" not in result
+    assert 'run_sql(sql="...")' in result
+
+
+def test_instructions_keep_validate_when_supported():
+    """Default instructions include validate_sql workflow."""
+    assert "validate_sql" in INSTRUCTIONS_SHELL_MODE
+    assert 'run_sql(query_id="...")' in INSTRUCTIONS_SHELL_MODE


### PR DESCRIPTION
## Problem

When a connector has `supports_validate_sql: false` (e.g., Dune API with DuneSQL dialect), the server system prompt still directed Claude to use the `validate_sql → run_sql(query_id)` workflow. Even though the `validate_sql` tool wasn't registered, Claude would try to follow the instructions and get stuck.

## Root Cause

The server instructions (`INSTRUCTIONS_SHELL_MODE` / `INSTRUCTIONS_DETAILED`) were static strings that always included:
- `validate_sql(sql="...")` in the workflow steps
- `validate_sql` in the tools list
- `run_sql(query_id="...")` as the execution step

These were never adapted based on connector capabilities.

## Fix

Added `_strip_validate_sql_from_instructions()` that rewrites the system prompt when `supports_validate_sql=false`:
- Removes `validate_sql` from workflow steps and tool lists
- Changes `run_sql(query_id="...")` to `run_sql(sql="...")` with "Execute directly" comment
- Called during server creation based on connector capabilities

The `_run_sql` function itself already handled direct SQL correctly — the issue was purely in the guidance given to Claude.

## Tests

- `test_server_instructions.py`: Verifies instruction adaptation strips/keeps validate_sql
- `test_run_sql.py`: Added tests for response content and no-params guidance
- All 53 related tests pass