### PR TITLE
feat: db-mcp uninstall + update commands; fix UI static mount

### DIFF
--- a/packages/cli/src/db_mcp_cli/commands/install_cmd.py
+++ b/packages/cli/src/db_mcp_cli/commands/install_cmd.py
@@ -1,0 +1,317 @@
+"""Install lifecycle commands: uninstall and update."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import stat
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import click
+from rich.panel import Panel
+from rich.prompt import Confirm
+
+from db_mcp_cli.utils import (
+    CONFIG_DIR,
+    _get_cli_version,
+    console,
+)
+
+REPO = "apelogic-ai/db-mcp"
+DEFAULT_INSTALL_DIR = Path.home() / ".local" / "bin"
+CACHE_DIR = CONFIG_DIR / "cache"
+
+
+def _detect_platform() -> str:
+    """Return the platform suffix used in release artifact names."""
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    if machine in ("x86_64", "amd64"):
+        arch = "x64"
+    elif machine in ("arm64", "aarch64"):
+        arch = "arm64"
+    else:
+        raise click.ClickException(f"Unsupported architecture: {machine}")
+
+    if system == "darwin":
+        os_name = "macos"
+    elif system == "linux":
+        os_name = "linux"
+    elif system.startswith(("win", "msys", "mingw", "cygwin")):
+        os_name = "windows"
+    else:
+        raise click.ClickException(f"Unsupported operating system: {system}")
+
+    return f"{os_name}-{arch}"
+
+
+def _resolve_binary_path() -> Path:
+    """Resolve the installed db-mcp binary path.
+
+    Order:
+      1. ``DB_MCP_INSTALL`` env var (matches install.sh)
+      2. ``sys.argv[0]`` if it points at an existing file
+      3. ``$PATH`` lookup for ``db-mcp``
+      4. Fallback: ``~/.local/bin/db-mcp``
+    """
+    install_env = os.environ.get("DB_MCP_INSTALL", "").strip()
+    if install_env:
+        return Path(install_env).expanduser() / "db-mcp"
+
+    argv0 = Path(sys.argv[0]) if sys.argv and sys.argv[0] else None
+    if argv0 and argv0.exists() and argv0.is_file():
+        return argv0.resolve(strict=False)
+
+    which_path = shutil.which("db-mcp")
+    if which_path:
+        return Path(which_path)
+
+    return DEFAULT_INSTALL_DIR / "db-mcp"
+
+
+def _fetch_latest_version(timeout: float = 5.0) -> str | None:
+    """Query GitHub for the latest release tag. Returns version string without 'v' prefix.
+
+    Returns None on network/parse errors.
+    """
+    url = f"https://api.github.com/repos/{REPO}/releases/latest"
+    try:
+        req = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.load(resp)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
+        return None
+
+    tag = data.get("tag_name") or ""
+    if tag.startswith("v"):
+        tag = tag[1:]
+    return tag or None
+
+
+def _download_to(url: str, dest: Path, timeout: float = 60.0) -> None:
+    """Download a URL to dest. Raises ClickException on failure."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            if resp.status != 200:
+                raise click.ClickException(
+                    f"Download failed: HTTP {resp.status} for {url}"
+                )
+            with open(dest, "wb") as f:
+                shutil.copyfileobj(resp, f)
+    except urllib.error.HTTPError as e:
+        raise click.ClickException(f"Download failed: HTTP {e.code} for {url}") from e
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        raise click.ClickException(f"Download failed: {e} ({url})") from e
+
+    dest.chmod(dest.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _install_binary(version: str, binary_path: Path) -> Path:
+    """Install the binary for the given version. Returns the final binary path.
+
+    On macOS we cache versioned binaries under ``CACHE_DIR`` and symlink, mirroring
+    install.sh. On Linux/Windows the binary is downloaded directly to ``binary_path``.
+    """
+    plat = _detect_platform()
+    ext = ".exe" if plat.startswith("windows-") else ""
+    filename = f"db-mcp-{plat}{ext}"
+    url = f"https://github.com/{REPO}/releases/download/v{version}/{filename}"
+
+    console.print(f"[blue]Downloading db-mcp v{version} for {plat}...[/blue]")
+    console.print(f"  URL: {url}")
+
+    if plat.startswith("macos-"):
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        cache_path = CACHE_DIR / f"db-mcp-{version}{ext}"
+        _download_to(url, cache_path)
+        if binary_path.exists() or binary_path.is_symlink():
+            binary_path.unlink()
+        binary_path.parent.mkdir(parents=True, exist_ok=True)
+        binary_path.symlink_to(cache_path)
+
+        # Strip macOS quarantine if present (install.sh does the same).
+        try:
+            subprocess.run(
+                ["xattr", "-d", "com.apple.quarantine", str(cache_path)],
+                check=False,
+                capture_output=True,
+            )
+        except FileNotFoundError:
+            pass
+    else:
+        _download_to(url, binary_path)
+
+    return binary_path
+
+
+# ---------------------------------------------------------------------------
+# uninstall
+# ---------------------------------------------------------------------------
+
+
+@click.command("uninstall")
+@click.option(
+    "--purge",
+    is_flag=True,
+    help="Also delete ~/.db-mcp (config, connections, cached binaries, knowledge vault).",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Skip interactive confirmations (DANGEROUS — deletes immediately).",
+)
+def uninstall_cmd(purge: bool, yes: bool) -> None:
+    """Uninstall db-mcp. Removes the binary; --purge also wipes ~/.db-mcp.
+
+    \b
+    Examples:
+      db-mcp uninstall                 Remove only the binary
+      db-mcp uninstall --purge         Remove binary + all config/connections
+      db-mcp uninstall --purge -y      Same, no confirmation prompts
+    """
+    binary_path = _resolve_binary_path()
+    binary_target = binary_path.resolve(strict=False) if binary_path.exists() else binary_path
+
+    summary_lines = [
+        "[bold]Will remove:[/bold]",
+        f"  • binary: [cyan]{binary_path}[/cyan]",
+    ]
+    if binary_path.is_symlink() and binary_target != binary_path:
+        summary_lines.append(f"    → cached: [cyan]{binary_target}[/cyan]")
+    if purge:
+        summary_lines.append(f"  • config:  [cyan]{CONFIG_DIR}[/cyan]")
+    console.print(Panel.fit("\n".join(summary_lines), border_style="yellow"))
+
+    if not binary_path.exists() and not binary_path.is_symlink():
+        if not purge:
+            console.print("[yellow]No db-mcp binary found at the resolved path.[/yellow]")
+            return
+        console.print("[dim]No db-mcp binary found; will only purge config.[/dim]")
+
+    if not yes:
+        if not Confirm.ask("Proceed with uninstall?", default=False):
+            console.print("[dim]Aborted.[/dim]")
+            return
+        if purge and not Confirm.ask(
+            f"[red]Really delete {CONFIG_DIR}? This is irreversible.[/red]",
+            default=False,
+        ):
+            console.print("[dim]Aborted.[/dim]")
+            return
+
+    # Remove binary (and cached target if symlink).
+    if binary_path.is_symlink():
+        try:
+            binary_path.unlink()
+            console.print(f"[green]Removed symlink:[/green] {binary_path}")
+        except OSError as e:
+            console.print(f"[red]Failed to remove {binary_path}: {e}[/red]")
+        if binary_target.exists() and binary_target != binary_path:
+            try:
+                binary_target.unlink()
+                console.print(f"[green]Removed cached binary:[/green] {binary_target}")
+            except OSError as e:
+                console.print(f"[red]Failed to remove {binary_target}: {e}[/red]")
+    elif binary_path.exists():
+        try:
+            binary_path.unlink()
+            console.print(f"[green]Removed binary:[/green] {binary_path}")
+        except OSError as e:
+            console.print(f"[red]Failed to remove {binary_path}: {e}[/red]")
+
+    if purge and CONFIG_DIR.exists():
+        try:
+            shutil.rmtree(CONFIG_DIR)
+            console.print(f"[green]Removed config dir:[/green] {CONFIG_DIR}")
+        except OSError as e:
+            console.print(f"[red]Failed to remove {CONFIG_DIR}: {e}[/red]")
+
+    console.print("[bold green]✓ Uninstall complete.[/bold green]")
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+
+@click.command("update")
+@click.option(
+    "--check",
+    is_flag=True,
+    help="Only check for a newer version; do not install.",
+)
+@click.option(
+    "--version",
+    "version_override",
+    default=None,
+    help="Install a specific version (e.g. 0.9.11) instead of latest.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Skip the install confirmation prompt.",
+)
+def update_cmd(check: bool, version_override: str | None, yes: bool) -> None:
+    """Check for and install a newer db-mcp release.
+
+    \b
+    Examples:
+      db-mcp update                Check and install the latest release
+      db-mcp update --check        Only check; print whether an update is available
+      db-mcp update --version 0.9.11   Install a specific version
+    """
+    current = _get_cli_version()
+
+    target: str | None
+    if version_override:
+        target = version_override.lstrip("v")
+        console.print(f"Target version: [green]{target}[/green]  (current: {current})")
+    else:
+        console.print("Checking for the latest release...")
+        target = _fetch_latest_version()
+        if target is None:
+            raise click.ClickException(
+                "Could not contact GitHub to determine the latest version."
+            )
+        console.print(f"Latest:  [green]{target}[/green]")
+        console.print(f"Current: [cyan]{current}[/cyan]")
+
+        if target == current:
+            console.print("[bold green]✓ Already up to date.[/bold green]")
+            return
+
+    if check:
+        console.print(f"[yellow]Update available: {current} → {target}[/yellow]")
+        return
+
+    if not yes and not Confirm.ask(
+        f"Install db-mcp v{target} (replacing {current})?", default=True
+    ):
+        console.print("[dim]Aborted.[/dim]")
+        return
+
+    binary_path = _resolve_binary_path()
+    _install_binary(target, binary_path)
+    console.print(
+        f"[bold green]✓ Installed db-mcp v{target}[/bold green] at "
+        f"[cyan]{binary_path}[/cyan]"
+    )
+    console.print(
+        "[dim]Run 'db-mcp --version' in a new shell to confirm.[/dim]"
+    )
+
+
+def register_commands(main_group: click.Group) -> None:
+    """Register install lifecycle commands."""
+    main_group.add_command(uninstall_cmd)
+    main_group.add_command(update_cmd)

--- a/packages/cli/src/db_mcp_cli/main.py
+++ b/packages/cli/src/db_mcp_cli/main.py
@@ -16,6 +16,7 @@ from db_mcp_cli.commands.examples_cmd import register_commands as register_examp
 from db_mcp_cli.commands.gaps_cmd import register_commands as register_gaps
 from db_mcp_cli.commands.git_cmds import register_commands as register_git
 from db_mcp_cli.commands.insider import register_commands as register_insider
+from db_mcp_cli.commands.install_cmd import register_commands as register_install
 from db_mcp_cli.commands.metrics_cmd import register_commands as register_metrics
 from db_mcp_cli.commands.query_cmd import register_commands as register_query
 from db_mcp_cli.commands.rules_cmd import register_commands as register_rules
@@ -31,6 +32,9 @@ HELP_SECTIONS = [
         ("", [
             "tui", "ui", "status", "config",
             "agents", "playground",
+        ]),
+        ("Install", [
+            "update", "uninstall",
         ]),
     ]),
     ("Connection", [
@@ -119,6 +123,7 @@ register_schema(main)
 register_gaps(main)
 register_domain(main)
 register_query(main)
+register_install(main)
 
 
 if __name__ == "__main__":

--- a/packages/cli/tests/test_install_cmd.py
+++ b/packages/cli/tests/test_install_cmd.py
@@ -1,0 +1,313 @@
+"""Tests for db-mcp uninstall and update commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from db_mcp_cli.commands import install_cmd
+from db_mcp_cli.main import main
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_install(tmp_path, monkeypatch):
+    """Build a sandbox: ~/.db-mcp under tmp_path and a fake installed binary."""
+    config_dir = tmp_path / ".db-mcp"
+    cache_dir = config_dir / "cache"
+    cache_dir.mkdir(parents=True)
+    install_dir = tmp_path / ".local" / "bin"
+    install_dir.mkdir(parents=True)
+
+    cached = cache_dir / "db-mcp-0.9.11"
+    cached.write_bytes(b"#!/bin/sh\nexit 0\n")
+    cached.chmod(0o755)
+
+    binary = install_dir / "db-mcp"
+    binary.symlink_to(cached)
+
+    # Some content under the config dir to verify --purge actually wipes it.
+    (config_dir / "config.yaml").write_text("active_connection: dev\n")
+    (config_dir / "connections").mkdir()
+    (config_dir / "connections" / "dev").mkdir()
+    (config_dir / "connections" / "dev" / ".env").write_text("DATABASE_URL=sqlite:///x\n")
+
+    monkeypatch.setenv("DB_MCP_INSTALL", str(install_dir))
+    monkeypatch.setattr(install_cmd, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(install_cmd, "CACHE_DIR", cache_dir)
+    monkeypatch.setattr(install_cmd, "DEFAULT_INSTALL_DIR", install_dir)
+
+    return {
+        "config_dir": config_dir,
+        "cache_dir": cache_dir,
+        "install_dir": install_dir,
+        "binary": binary,
+        "cached": cached,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _detect_platform / _resolve_binary_path
+# ---------------------------------------------------------------------------
+
+
+def test_detect_platform_macos_arm64(monkeypatch):
+    monkeypatch.setattr(install_cmd.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(install_cmd.platform, "machine", lambda: "arm64")
+    assert install_cmd._detect_platform() == "macos-arm64"
+
+
+def test_detect_platform_linux_x64(monkeypatch):
+    monkeypatch.setattr(install_cmd.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(install_cmd.platform, "machine", lambda: "x86_64")
+    assert install_cmd._detect_platform() == "linux-x64"
+
+
+def test_detect_platform_unsupported_arch(monkeypatch):
+    monkeypatch.setattr(install_cmd.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(install_cmd.platform, "machine", lambda: "riscv64")
+    with pytest.raises(install_cmd.click.ClickException):
+        install_cmd._detect_platform()
+
+
+def test_resolve_binary_path_uses_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("DB_MCP_INSTALL", str(tmp_path))
+    assert install_cmd._resolve_binary_path() == tmp_path / "db-mcp"
+
+
+def test_resolve_binary_path_falls_back_to_default(monkeypatch):
+    monkeypatch.delenv("DB_MCP_INSTALL", raising=False)
+    monkeypatch.setattr(install_cmd.sys, "argv", [""])
+    monkeypatch.setattr(install_cmd.shutil, "which", lambda _: None)
+    fake_default = Path("/tmp/fake-bin")
+    monkeypatch.setattr(install_cmd, "DEFAULT_INSTALL_DIR", fake_default)
+    assert install_cmd._resolve_binary_path() == fake_default / "db-mcp"
+
+
+# ---------------------------------------------------------------------------
+# uninstall
+# ---------------------------------------------------------------------------
+
+
+def test_uninstall_requires_confirmation_when_no_yes(fake_install):
+    runner = CliRunner()
+    # Provide "n" to the confirmation; binary should remain.
+    result = runner.invoke(main, ["uninstall"], input="n\n")
+    assert result.exit_code == 0
+    assert "Aborted" in result.output
+    assert fake_install["binary"].is_symlink()
+    assert fake_install["cached"].exists()
+
+
+def test_uninstall_removes_binary_only(fake_install):
+    runner = CliRunner()
+    result = runner.invoke(main, ["uninstall", "-y"])
+    assert result.exit_code == 0, result.output
+    assert not fake_install["binary"].exists()
+    assert not fake_install["binary"].is_symlink()
+    assert not fake_install["cached"].exists()
+    # Config dir must remain untouched without --purge.
+    assert fake_install["config_dir"].exists()
+    assert (fake_install["config_dir"] / "config.yaml").exists()
+
+
+def test_uninstall_purge_removes_config(fake_install):
+    runner = CliRunner()
+    result = runner.invoke(main, ["uninstall", "--purge", "-y"])
+    assert result.exit_code == 0, result.output
+    assert not fake_install["binary"].exists()
+    assert not fake_install["config_dir"].exists()
+
+
+def test_uninstall_purge_double_confirmation(fake_install):
+    """First prompt 'y', second prompt 'n' must abort and keep the config."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["uninstall", "--purge"], input="y\nn\n")
+    assert result.exit_code == 0
+    assert "Aborted" in result.output
+    # Binary preserved (uninstall not yet performed when second prompt declined).
+    assert fake_install["binary"].is_symlink()
+    assert fake_install["config_dir"].exists()
+
+
+def test_uninstall_purge_double_confirmation_both_yes(fake_install):
+    runner = CliRunner()
+    result = runner.invoke(main, ["uninstall", "--purge"], input="y\ny\n")
+    assert result.exit_code == 0, result.output
+    assert not fake_install["binary"].exists()
+    assert not fake_install["config_dir"].exists()
+
+
+def test_uninstall_missing_binary_without_purge(fake_install):
+    fake_install["binary"].unlink()
+    fake_install["cached"].unlink()
+    runner = CliRunner()
+    result = runner.invoke(main, ["uninstall", "-y"])
+    assert result.exit_code == 0
+    assert "No db-mcp binary found" in result.output
+    # Without --purge, missing binary returns early and config stays.
+    assert fake_install["config_dir"].exists()
+
+
+def test_uninstall_purge_when_binary_missing(fake_install):
+    fake_install["binary"].unlink()
+    fake_install["cached"].unlink()
+    runner = CliRunner()
+    result = runner.invoke(main, ["uninstall", "--purge", "-y"])
+    assert result.exit_code == 0, result.output
+    assert not fake_install["config_dir"].exists()
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+
+def test_update_check_already_latest(fake_install):
+    with patch.object(install_cmd, "_get_cli_version", return_value="0.9.11"), \
+         patch.object(install_cmd, "_fetch_latest_version", return_value="0.9.11"):
+        runner = CliRunner()
+        result = runner.invoke(main, ["update", "--check"])
+    assert result.exit_code == 0
+    assert "Already up to date" in result.output
+
+
+def test_update_check_available(fake_install):
+    with patch.object(install_cmd, "_get_cli_version", return_value="0.9.10"), \
+         patch.object(install_cmd, "_fetch_latest_version", return_value="0.9.11"):
+        runner = CliRunner()
+        result = runner.invoke(main, ["update", "--check"])
+    assert result.exit_code == 0
+    assert "Update available" in result.output
+    assert "0.9.10" in result.output and "0.9.11" in result.output
+
+
+def test_update_install_calls_install_binary(fake_install):
+    with patch.object(install_cmd, "_get_cli_version", return_value="0.9.10"), \
+         patch.object(install_cmd, "_fetch_latest_version", return_value="0.9.11"), \
+         patch.object(install_cmd, "_install_binary") as mock_install:
+        mock_install.return_value = fake_install["binary"]
+        runner = CliRunner()
+        result = runner.invoke(main, ["update", "-y"])
+    assert result.exit_code == 0, result.output
+    mock_install.assert_called_once()
+    # First positional arg is the version.
+    assert mock_install.call_args.args[0] == "0.9.11"
+
+
+def test_update_aborts_when_user_declines(fake_install):
+    with patch.object(install_cmd, "_get_cli_version", return_value="0.9.10"), \
+         patch.object(install_cmd, "_fetch_latest_version", return_value="0.9.11"), \
+         patch.object(install_cmd, "_install_binary") as mock_install:
+        runner = CliRunner()
+        result = runner.invoke(main, ["update"], input="n\n")
+    assert result.exit_code == 0
+    assert "Aborted" in result.output
+    mock_install.assert_not_called()
+
+
+def test_update_explicit_version_skips_fetch(fake_install):
+    with patch.object(install_cmd, "_get_cli_version", return_value="0.9.10"), \
+         patch.object(install_cmd, "_fetch_latest_version") as fetch, \
+         patch.object(install_cmd, "_install_binary") as mock_install:
+        runner = CliRunner()
+        result = runner.invoke(main, ["update", "--version", "0.8.7", "-y"])
+    assert result.exit_code == 0, result.output
+    fetch.assert_not_called()
+    mock_install.assert_called_once()
+    assert mock_install.call_args.args[0] == "0.8.7"
+
+
+def test_update_explicit_version_strips_v_prefix(fake_install):
+    with patch.object(install_cmd, "_get_cli_version", return_value="0.9.10"), \
+         patch.object(install_cmd, "_install_binary") as mock_install:
+        runner = CliRunner()
+        result = runner.invoke(main, ["update", "--version", "v0.9.11", "-y"])
+    assert result.exit_code == 0, result.output
+    assert mock_install.call_args.args[0] == "0.9.11"
+
+
+def test_update_fails_when_github_unreachable(fake_install):
+    with patch.object(install_cmd, "_fetch_latest_version", return_value=None):
+        runner = CliRunner()
+        result = runner.invoke(main, ["update"])
+    assert result.exit_code != 0
+    assert "Could not contact GitHub" in result.output
+
+
+# ---------------------------------------------------------------------------
+# _install_binary (integration-ish; mocks the network layer)
+# ---------------------------------------------------------------------------
+
+
+def test_install_binary_macos_creates_symlink(fake_install, monkeypatch):
+    monkeypatch.setattr(install_cmd, "_detect_platform", lambda: "macos-arm64")
+
+    def fake_download(url, dest, timeout=60.0):
+        dest.write_bytes(b"new-binary-bytes")
+
+    monkeypatch.setattr(install_cmd, "_download_to", fake_download)
+
+    binary = fake_install["binary"]
+    install_cmd._install_binary("0.9.12", binary)
+
+    new_cached = fake_install["cache_dir"] / "db-mcp-0.9.12"
+    assert new_cached.exists()
+    assert binary.is_symlink()
+    assert binary.resolve() == new_cached.resolve()
+
+
+def test_install_binary_linux_writes_directly(fake_install, monkeypatch):
+    monkeypatch.setattr(install_cmd, "_detect_platform", lambda: "linux-x64")
+
+    fake_install["binary"].unlink()  # start from empty
+    written = []
+
+    def fake_download(url, dest, timeout=60.0):
+        written.append(dest)
+        dest.write_bytes(b"new-binary-bytes")
+
+    monkeypatch.setattr(install_cmd, "_download_to", fake_download)
+
+    install_cmd._install_binary("0.9.12", fake_install["binary"])
+    assert fake_install["binary"].exists()
+    assert not fake_install["binary"].is_symlink()
+    assert written == [fake_install["binary"]]
+
+
+def test_fetch_latest_version_handles_network_error(monkeypatch):
+    import urllib.error
+
+    def boom(*args, **kwargs):
+        raise urllib.error.URLError("offline")
+
+    monkeypatch.setattr(install_cmd.urllib.request, "urlopen", boom)
+    assert install_cmd._fetch_latest_version() is None
+
+
+def test_fetch_latest_version_parses_tag(monkeypatch):
+    class FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self):
+            return b'{"tag_name": "v1.2.3"}'
+
+    def fake_open(req, timeout=5.0):
+        return FakeResp()
+
+    # urllib.request.json.load reads from the response object; emulate it.
+    import json as _json
+
+    monkeypatch.setattr(install_cmd.urllib.request, "urlopen", fake_open)
+    monkeypatch.setattr(install_cmd.json, "load", lambda f: _json.loads(f.read()))
+    assert install_cmd._fetch_latest_version() == "1.2.3"

--- a/packages/core/src/db_mcp/ui_server.py
+++ b/packages/core/src/db_mcp/ui_server.py
@@ -284,9 +284,22 @@ def create_app(mount_mcp: bool = False) -> FastAPI:
         del name
         return _serve_exported_page("connection/knowledge")
 
-    # Mount static files if directory exists
-    if STATIC_DIR.exists():
-        app.mount("/", StaticFiles(directory=STATIC_DIR, html=True), name="static")
+    # Mount static files. Use check_dir=False so mount registers even if the
+    # bundle hasn't finished extracting at construction time; StaticFiles will
+    # 404 individual files if the dir is genuinely missing at request time.
+    static_exists = STATIC_DIR.exists()
+    logger.info(
+        "Mounting static files: STATIC_DIR=%s exists=%s frozen=%s _MEIPASS=%s",
+        STATIC_DIR,
+        static_exists,
+        getattr(__import__("sys"), "frozen", False),
+        getattr(__import__("sys"), "_MEIPASS", None),
+    )
+    app.mount(
+        "/",
+        StaticFiles(directory=str(STATIC_DIR), html=True, check_dir=False),
+        name="static",
+    )
 
     return app
 


### PR DESCRIPTION
## Summary
- New `db-mcp uninstall` command — removes the installed binary; `--purge` (behind a second confirmation) wipes `~/.db-mcp`. Mirrors install.sh's macOS symlink-via-cache layout so it works for installer-installed binaries.
- New `db-mcp update` command — queries GitHub for the latest release, compares to current, and reinstalls in place. Supports `--check` (no install), `--version X.Y.Z` (pin), and `-y` (skip confirmation).
- Bug fix in `ui_server.py` — removes the silent-fail `if STATIC_DIR.exists()` guard that caused v0.9.11 binaries in the wild to return `{"detail":"Not Found"}` for every page when the PyInstaller bundle's static dir wasn't usable at `create_app()` time. Replaced with `StaticFiles(check_dir=False)` so the mount registers unconditionally; individual file requests cleanly 404 if the dir is genuinely missing. Adds a one-line diagnostic log so the static-dir state is always visible in `~/.db-mcp/ui-server.log`.

## Test plan
- [x] 23 new unit tests in `packages/cli/tests/test_install_cmd.py` (platform detection, binary path resolution, uninstall confirmation flows, `--purge` double-confirm, update install/check paths) — all pass.
- [x] Full repo test matrix green: cli (68), core (1157), data (299), knowledge (249), mcp-server (47) = **1820 passing**.
- [x] `uv run ruff check .` clean.
- [x] `db-mcp --help` shows the new commands under a new "Install" subsection.
- [x] Manually verified PyInstaller build of this branch loads UI correctly (panel renders, `/connections/` returns 200, all `_next/*` assets serve, log shows `Mounting static files: ... exists=True`).
- [ ] Reviewer: confirm `db-mcp update --check` against your installed version reports correctly.
- [ ] Reviewer: dry-run `db-mcp uninstall` (declines confirmation) leaves binary intact.

## Notes
- Why `check_dir=False` is the right fix: the PyInstaller-onefile bundle extracts files to a temp dir before Python runs, but in some environments the `db_mcp/static/` subtree's `Path.exists()` check returned False at the moment `create_app()` ran, even though the directory was present on disk a moment later. `check_dir=False` lets the StaticFiles mount register regardless, deferring the existence check to per-request time. The diagnostic log line means the next time this misbehaves, we'll see exactly which of `STATIC_DIR`, `_MEIPASS`, or `frozen` is unexpected.
- `update` reuses the same `~/.db-mcp/cache/` symlink pattern as `scripts/install.sh`, so an `update` followed by `uninstall` cleanly removes both the cached versioned binary and the symlink.