### PR TITLE
fix: db-mcp update — bundle CA certs via certifi for SSL verification

### DIFF
--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "click>=8.0.0",
     "rich>=13.0.0",
     "fastmcp>=2.0.0",
+    "certifi>=2024.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/cli/src/db_mcp_cli/commands/install_cmd.py
+++ b/packages/cli/src/db_mcp_cli/commands/install_cmd.py
@@ -6,6 +6,7 @@ import json
 import os
 import platform
 import shutil
+import ssl
 import stat
 import subprocess
 import sys
@@ -13,6 +14,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+import certifi
 import click
 from rich.panel import Panel
 from rich.prompt import Confirm
@@ -26,6 +28,17 @@ from db_mcp_cli.utils import (
 REPO = "apelogic-ai/db-mcp"
 DEFAULT_INSTALL_DIR = Path.home() / ".local" / "bin"
 CACHE_DIR = CONFIG_DIR / "cache"
+
+
+def _ssl_context() -> ssl.SSLContext:
+    """Build an SSLContext using certifi's bundled CA store.
+
+    Frozen PyInstaller binaries can't reach the system trust store, so
+    `urlopen("https://...")` fails verification. Pointing OpenSSL at the
+    certifi bundle (which ships with the Python wheel and is included in
+    the PyInstaller bundle automatically) avoids that.
+    """
+    return ssl.create_default_context(cafile=certifi.where())
 
 
 def _detect_platform() -> str:
@@ -76,30 +89,31 @@ def _resolve_binary_path() -> Path:
     return DEFAULT_INSTALL_DIR / "db-mcp"
 
 
-def _fetch_latest_version(timeout: float = 5.0) -> str | None:
-    """Query GitHub for the latest release tag. Returns version string without 'v' prefix.
+def _fetch_latest_version(timeout: float = 5.0) -> tuple[str | None, str | None]:
+    """Query GitHub for the latest release tag.
 
-    Returns None on network/parse errors.
+    Returns ``(version, error)`` where ``version`` is the tag without the 'v'
+    prefix on success, or ``None`` with a human-readable ``error`` on failure.
     """
     url = f"https://api.github.com/repos/{REPO}/releases/latest"
     try:
         req = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json"})
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with urllib.request.urlopen(req, timeout=timeout, context=_ssl_context()) as resp:
             data = json.load(resp)
-    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
-        return None
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as e:
+        return None, str(e)
 
     tag = data.get("tag_name") or ""
     if tag.startswith("v"):
         tag = tag[1:]
-    return tag or None
+    return (tag or None), None
 
 
 def _download_to(url: str, dest: Path, timeout: float = 60.0) -> None:
     """Download a URL to dest. Raises ClickException on failure."""
     dest.parent.mkdir(parents=True, exist_ok=True)
     try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
+        with urllib.request.urlopen(url, timeout=timeout, context=_ssl_context()) as resp:
             if resp.status != 200:
                 raise click.ClickException(
                     f"Download failed: HTTP {resp.status} for {url}"
@@ -278,10 +292,10 @@ def update_cmd(check: bool, version_override: str | None, yes: bool) -> None:
         console.print(f"Target version: [green]{target}[/green]  (current: {current})")
     else:
         console.print("Checking for the latest release...")
-        target = _fetch_latest_version()
+        target, fetch_error = _fetch_latest_version()
         if target is None:
             raise click.ClickException(
-                "Could not contact GitHub to determine the latest version."
+                f"Could not contact GitHub to determine the latest version: {fetch_error}"
             )
         console.print(f"Latest:  [green]{target}[/green]")
         console.print(f"Current: [cyan]{current}[/cyan]")

--- a/packages/cli/tests/test_install_cmd.py
+++ b/packages/cli/tests/test_install_cmd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -171,7 +172,7 @@ def test_uninstall_purge_when_binary_missing(fake_install):
 
 def test_update_check_already_latest(fake_install):
     with patch.object(install_cmd, "_get_cli_version", return_value="0.9.11"), \
-         patch.object(install_cmd, "_fetch_latest_version", return_value="0.9.11"):
+         patch.object(install_cmd, "_fetch_latest_version", return_value=("0.9.11", None)):
         runner = CliRunner()
         result = runner.invoke(main, ["update", "--check"])
     assert result.exit_code == 0
@@ -180,7 +181,7 @@ def test_update_check_already_latest(fake_install):
 
 def test_update_check_available(fake_install):
     with patch.object(install_cmd, "_get_cli_version", return_value="0.9.10"), \
-         patch.object(install_cmd, "_fetch_latest_version", return_value="0.9.11"):
+         patch.object(install_cmd, "_fetch_latest_version", return_value=("0.9.11", None)):
         runner = CliRunner()
         result = runner.invoke(main, ["update", "--check"])
     assert result.exit_code == 0
@@ -190,7 +191,7 @@ def test_update_check_available(fake_install):
 
 def test_update_install_calls_install_binary(fake_install):
     with patch.object(install_cmd, "_get_cli_version", return_value="0.9.10"), \
-         patch.object(install_cmd, "_fetch_latest_version", return_value="0.9.11"), \
+         patch.object(install_cmd, "_fetch_latest_version", return_value=("0.9.11", None)), \
          patch.object(install_cmd, "_install_binary") as mock_install:
         mock_install.return_value = fake_install["binary"]
         runner = CliRunner()
@@ -203,7 +204,7 @@ def test_update_install_calls_install_binary(fake_install):
 
 def test_update_aborts_when_user_declines(fake_install):
     with patch.object(install_cmd, "_get_cli_version", return_value="0.9.10"), \
-         patch.object(install_cmd, "_fetch_latest_version", return_value="0.9.11"), \
+         patch.object(install_cmd, "_fetch_latest_version", return_value=("0.9.11", None)), \
          patch.object(install_cmd, "_install_binary") as mock_install:
         runner = CliRunner()
         result = runner.invoke(main, ["update"], input="n\n")
@@ -234,11 +235,14 @@ def test_update_explicit_version_strips_v_prefix(fake_install):
 
 
 def test_update_fails_when_github_unreachable(fake_install):
-    with patch.object(install_cmd, "_fetch_latest_version", return_value=None):
+    error = "<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED]>"
+    with patch.object(install_cmd, "_fetch_latest_version", return_value=(None, error)):
         runner = CliRunner()
         result = runner.invoke(main, ["update"])
     assert result.exit_code != 0
     assert "Could not contact GitHub" in result.output
+    # The underlying error must be surfaced so users can diagnose SSL/network issues.
+    assert "CERTIFICATE_VERIFY_FAILED" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -288,7 +292,9 @@ def test_fetch_latest_version_handles_network_error(monkeypatch):
         raise urllib.error.URLError("offline")
 
     monkeypatch.setattr(install_cmd.urllib.request, "urlopen", boom)
-    assert install_cmd._fetch_latest_version() is None
+    version, error = install_cmd._fetch_latest_version()
+    assert version is None
+    assert "offline" in error
 
 
 def test_fetch_latest_version_parses_tag(monkeypatch):
@@ -302,7 +308,7 @@ def test_fetch_latest_version_parses_tag(monkeypatch):
         def read(self):
             return b'{"tag_name": "v1.2.3"}'
 
-    def fake_open(req, timeout=5.0):
+    def fake_open(req, timeout=5.0, context=None):
         return FakeResp()
 
     # urllib.request.json.load reads from the response object; emulate it.
@@ -310,4 +316,76 @@ def test_fetch_latest_version_parses_tag(monkeypatch):
 
     monkeypatch.setattr(install_cmd.urllib.request, "urlopen", fake_open)
     monkeypatch.setattr(install_cmd.json, "load", lambda f: _json.loads(f.read()))
-    assert install_cmd._fetch_latest_version() == "1.2.3"
+    version, error = install_cmd._fetch_latest_version()
+    assert version == "1.2.3"
+    assert error is None
+
+
+def test_ssl_context_uses_certifi_bundle():
+    """The SSL context must be configured from certifi's CA bundle so frozen
+    PyInstaller binaries can verify HTTPS endpoints."""
+    import certifi
+    import ssl
+
+    ctx = install_cmd._ssl_context()
+    assert isinstance(ctx, ssl.SSLContext)
+    # Verification must be on (default), and the context should have loaded
+    # at least the certifi bundle's CAs.
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    # Ensure the helper actually points at certifi (sanity-check the path exists).
+    assert os.path.isfile(certifi.where())
+
+
+def test_fetch_latest_version_passes_ssl_context(monkeypatch):
+    """Regression test for v0.9.12 — without certifi, urlopen raised
+    SSL: CERTIFICATE_VERIFY_FAILED inside the PyInstaller bundle."""
+    captured = {}
+
+    class FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self):
+            return b'{"tag_name": "v9.9.9"}'
+
+    def fake_open(req, timeout=5.0, context=None):
+        captured["context"] = context
+        return FakeResp()
+
+    import json as _json
+    import ssl
+
+    monkeypatch.setattr(install_cmd.urllib.request, "urlopen", fake_open)
+    monkeypatch.setattr(install_cmd.json, "load", lambda f: _json.loads(f.read()))
+    install_cmd._fetch_latest_version()
+    assert isinstance(captured["context"], ssl.SSLContext)
+
+
+def test_download_to_passes_ssl_context(monkeypatch, tmp_path):
+    """Same regression — _download_to must also pass an SSLContext."""
+    captured = {}
+
+    class FakeResp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self, n=-1):
+            return b""
+
+    def fake_open(url, timeout=60.0, context=None):
+        captured["context"] = context
+        return FakeResp()
+
+    import ssl
+
+    monkeypatch.setattr(install_cmd.urllib.request, "urlopen", fake_open)
+    install_cmd._download_to("https://example.test/x", tmp_path / "out.bin")
+    assert isinstance(captured["context"], ssl.SSLContext)

--- a/uv.lock
+++ b/uv.lock
@@ -700,6 +700,7 @@ name = "db-mcp-cli"
 version = "0.1.0"
 source = { editable = "packages/cli" }
 dependencies = [
+    { name = "certifi" },
     { name = "click" },
     { name = "db-mcp" },
     { name = "db-mcp-data" },
@@ -718,6 +719,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "certifi", specifier = ">=2024.2.2" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "db-mcp", editable = "packages/core" },
     { name = "db-mcp-data", editable = "packages/data" },


### PR DESCRIPTION
## Summary
v0.9.12 shipped with `db-mcp update` and `db-mcp uninstall` but the **update** path was broken on the PyInstaller binaries: every HTTPS call inside the bundle failed with `SSL: CERTIFICATE_VERIFY_FAILED` because frozen Python has no access to the system CA store.

This PR:
- Adds `certifi>=2024.2.2` as an explicit dependency of `packages/cli`.
- Wraps every `urlopen()` call in `install_cmd.py` with an `SSLContext` built from `certifi.where()`.
- Changes `_fetch_latest_version()` to return `(version, error)` so the underlying SSL/network exception is surfaced in the CLI output, not swallowed as a generic "Could not contact GitHub" message.
- Adds regression tests asserting that both the GitHub API path (`_fetch_latest_version`) and the binary download path (`_download_to`) pass an `SSLContext` to `urlopen`.

## Reproduction (against v0.9.12 binary)
```
$ db-mcp update
Checking for the latest release...
Error: Could not contact GitHub to determine the latest version.

$ db-mcp update --version 0.9.12 -y
Downloading db-mcp v0.9.12 for macos-arm64...
  URL: https://github.com/apelogic-ai/db-mcp/releases/download/v0.9.12/db-mcp-macos-arm64
Error: Download failed: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] ...>
```

## After
Live source-mode test (proves the live HTTPS call now succeeds):
```
$ uv run python -c "from db_mcp_cli.commands.install_cmd import _fetch_latest_version; print(_fetch_latest_version())"
('0.9.12', None)
```
The CLI also prints a useful diagnostic on failure now, e.g.:
```
Error: Could not contact GitHub to determine the latest version: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] ...>
```

## Test plan
- [x] 26 unit tests pass (3 new — `test_ssl_context_uses_certifi_bundle`, `test_fetch_latest_version_passes_ssl_context`, `test_download_to_passes_ssl_context`; existing 23 updated for new tuple return).
- [x] Full repo: cli (71), core (1157), data (299), knowledge (249), mcp-server (47) = **1823 passing**.
- [x] `uv run --with ruff ruff check .` clean.
- [x] Live source-mode `_fetch_latest_version()` round-trip against api.github.com returns `("0.9.12", None)`.
- [ ] Reviewer: build a PyInstaller binary off this branch, run `db-mcp update --check` against it, confirm it reports the available version instead of failing.
- [ ] Reviewer: `db-mcp update --version 0.9.12 -y` against the new binary should succeed (download path uses certifi).

## Why explicit dep when certifi is already in `uv.lock`?
Yes, certifi is a transitive of several existing deps (httpx, requests, etc.). I added it explicitly to `packages/cli/pyproject.toml` so future dependency cleanups can't accidentally remove the only chain that pulls it in. PyInstaller's spec analysis already detects the import and bundles the CA file regardless.

## Suggested next release
This fix should ship as v0.9.13 — small, focused, no other changes piggybacking.